### PR TITLE
Fix gantt shortcode typo

### DIFF
--- a/layouts/shortcodes/gantt.html
+++ b/layouts/shortcodes/gantt.html
@@ -1,6 +1,6 @@
 <div id="gantt"></div>
 <script>
-	document.addEventsListener("DOMContentLoaded", function () {
+        document.addEventListener("DOMContentLoaded", function () {
 			const tasks = [
 					{{- range $i, $t := .Page.Pages -}}
 					{
@@ -9,7 +9,7 @@
 								start: "{{ $t.Params.start }}",
 								end: "{{ $t.Params.end }}",
 								progress: {{ if eq $t.Params.status "comp" }}100{{ else if eq $t.Params.status "go" }}50{{ else }}0{{ end }},
-								custiom_class: "status-{{ if eq $t.Params.status "comp" }}completed{{ else if eq $t.Params.status "go" }}in-progress{{ else }}not-started{{ end }} priority-{{ lower $t.Params.priority }}"
+                        custom_class: "status-{{ if eq $t.Params.status "comp" }}completed{{ else if eq $t.Params.status "go" }}in-progress{{ else }}not-started{{ end }} priority-{{ lower $t.Params.priority }}"
 						}{{ if lt (add $i 1) (len .Page.Pages) }}, {{ end }}
 					{{- end}}
 					];


### PR DESCRIPTION
## Summary
- fix typo in DOMContentLoaded listener in the gantt shortcode
- correct custom_class property for Frappe Gantt

## Testing
- `hugo --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bfc54dc58832aa3d14a1647383fe1