### PR TITLE
Fix config typos

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 baseURL = "https://cmdwolftech.gitlab.io/tasklist/"
 languageCode = "ja"
-title = "ProjectBorad"
+title = "ProjectBoard"
 
 [params]
   description = "sample"
@@ -24,5 +24,5 @@ title = "ProjectBorad"
   [[menu.main]]
     identifier = "contact"
     name = "otoiawase"
-    url = "/#contact-seciton"
+    url = "/#contact-section"
     weight = 3


### PR DESCRIPTION
## Summary
- correct site title in `config.toml`
- fix contact link typo

## Testing
- `hugo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c10537628832a818ec961258c3310