### PR TITLE
Add features and contact sections

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -2,6 +2,39 @@
 title: "Welcome to ProjectBoard"
 ---
 
+
+<section class="home-hero container">
 # Hello ProjectBoard
 
 [Project List]({{< relref "/projects/" >}})
+</section>
+
+<section id="features-section" class="home-features">
+## Features
+
+<div class="features-list">
+<div class="feature-item">
+### Task Management
+Keep track of project tasks with an easy Gantt view.
+</div>
+<div class="feature-item">
+### Priorities
+Visualize task priority and status at a glance.
+</div>
+<div class="feature-item">
+### Progress
+Monitor progress over time to stay on schedule.
+</div>
+</div>
+</section>
+
+<section id="contact-section" class="contact-section">
+## Contact
+
+<form>
+<label>Name<br><input type="text" name="name"></label>
+<label>Email<br><input type="email" name="email"></label>
+<label>Message<br><textarea name="message"></textarea></label>
+<button type="submit">Send</button>
+</form>
+</section>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -23,13 +23,14 @@
 	<header class="site-header">
 		<div class="container header-inner">
 			<h1 class="logo"><a href="{{ "/" | relURL }}">ProjectBoard</a></h1>
-			<nav class="main-nav">
-				<ul>
-					<li><a href="{{ "projects/" | relURL }}">Projects</a></li>
-					<li><a href="{{ "about/" | relURL }}">About</a></li>
-					<li id="today-date"></li>
-				</ul>
-			</nav>
+                <nav class="main-nav">
+                        <ul>
+                                {{ range .Site.Menus.main }}
+                                <li><a href="{{ .URL }}">{{ .Name }}</a></li>
+                                {{ end }}
+                                <li id="today-date"></li>
+                        </ul>
+                </nav>
 		</div>
 	</header>
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,5 +1,3 @@
 {{ define "main" }}
-<section class="home-hero container">
-	{{ .Content }}
-</section>
+{{ .Content }}
 {{ end }}

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -138,3 +138,67 @@ body {
 .priority-high rect.bar { stroke: #d9534f; stroke-width: 2; }
 .priority-medium rect.bar { stroke: #f0ad4e; stroke-width: 2; }
 .priority-low rect.bar { stroke: #5bc0de; stroke-width: 2; }
+
+/* Home Hero */
+.home-hero {
+        padding: 3em 0;
+        text-align: center;
+}
+
+.home-hero a {
+        display: inline-block;
+        margin-top: 1rem;
+        background: #333;
+        color: #fff;
+        padding: 0.5em 1em;
+        border-radius: 4px;
+        text-decoration: none;
+}
+
+/* Home Features */
+.home-features {
+        padding: 2em 0;
+}
+
+.features-list {
+        display: flex;
+        gap: 1.5em;
+        flex-wrap: wrap;
+}
+
+.feature-item {
+        flex: 1 1 30%;
+        background-color: #ffffff;
+        border: 1px solid #e0e0e0;
+        border-radius: 8px;
+        padding: 1em;
+        text-align: center;
+}
+
+.feature-item h3 {
+        margin-bottom: 0.5rem;
+}
+
+/* Contact */
+.contact-section {
+        padding: 2em 0;
+        background-color: #ffffff;
+}
+
+.contact-section form {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5em;
+}
+
+.contact-section input,
+.contact-section textarea {
+        padding: 0.5em;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+}
+
+.contact-section button {
+        align-self: flex-start;
+        padding: 0.5em 1em;
+}


### PR DESCRIPTION
## Summary
- dynamically generate header nav from config
- create hero, features and contact sections on the home page
- add styling for hero, features and contact sections
- simplify home layout to output page content

## Testing
- `hugo -D` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d3bcac898832ab325dd4ff9b9cdfa