### PR TITLE
Display project list on home page

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -5,9 +5,9 @@ title: "Welcome to ProjectBoard"
 
 <section class="home-hero container">
 # Hello ProjectBoard
-
-[Project List]({{< relref "/projects/" >}})
 </section>
+
+{{< project-list >}}
 
 <section id="features-section" class="home-features">
 ## Features

--- a/layouts/shortcodes/project-list.html
+++ b/layouts/shortcodes/project-list.html
@@ -1,0 +1,13 @@
+<section class="projects-list">
+    <h2 class="section-title">projectList</h2>
+    <div class="card-grid">
+        {{ range (site.GetPage "section" "projects").Pages }}
+        <a href="{{ .RelPermalink }}" class="card">
+            <div class="card-body">
+                <h3>{{ .Title }}</h3>
+                <p>{{ .Summary }}</p>
+            </div>
+        </a>
+        {{ end }}
+    </div>
+</section>


### PR DESCRIPTION
## Summary
- add `project-list` shortcode
- embed project list in home page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ded7e8a10832a991b974ece463e69