### PR TITLE
Add project progress bars to index

### DIFF
--- a/layouts/shortcodes/project-list.html
+++ b/layouts/shortcodes/project-list.html
@@ -2,10 +2,43 @@
     <h2 class="section-title">projectList</h2>
     <div class="card-grid">
         {{ range (site.GetPage "section" "projects").Pages }}
+        {{ $start := "" }}
+        {{ $end := "" }}
+        {{ $total := 0 }}
+        {{ $completed := 0 }}
+        {{ range .Pages }}
+            {{ $total = add $total 1 }}
+            {{ if .Params.start }}
+                {{ if not $start }}
+                    {{ $start = .Params.start }}
+                {{ else if lt (time .Params.start) (time $start) }}
+                    {{ $start = .Params.start }}
+                {{ end }}
+            {{ end }}
+            {{ if .Params.end }}
+                {{ if not $end }}
+                    {{ $end = .Params.end }}
+                {{ else if gt (time .Params.end) (time $end) }}
+                    {{ $end = .Params.end }}
+                {{ end }}
+            {{ end }}
+            {{ if eq .Params.status "comp" }}
+                {{ $completed = add $completed 1 }}
+            {{ end }}
+        {{ end }}
+        {{ $progress := 0.0 }}
+        {{ if gt $total 0 }}
+            {{ $progress = mul 100 (div (float $completed) (float $total)) }}
+        {{ end }}
         <a href="{{ .RelPermalink }}" class="card">
             <div class="card-body">
                 <h3>{{ .Title }}</h3>
                 <p>{{ .Summary }}</p>
+                <p class="project-dates">{{ $start }} - {{ $end }}</p>
+                <div class="progress">
+                    <div class="progress-bar" style="width: {{ printf "%.0f" $progress }}%"></div>
+                </div>
+                <p class="progress-label">{{ printf "%.0f" $progress }}%</p>
             </div>
         </a>
         {{ end }}

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -94,8 +94,34 @@ body {
 }
 
 .card-body p {
-	font-size: 0.95rem;
-	color: #666;
+        font-size: 0.95rem;
+        color: #666;
+}
+
+.project-dates {
+        font-size: 0.8rem;
+        color: #888;
+        margin-top: 0.25rem;
+}
+
+.progress {
+        background-color: #e0e0e0;
+        border-radius: 4px;
+        overflow: hidden;
+        height: 8px;
+        margin-top: 0.5rem;
+}
+
+.progress-bar {
+        height: 100%;
+        background-color: #5cb85c;
+}
+
+.progress-label {
+        font-size: 0.8rem;
+        text-align: right;
+        margin-top: 0.25rem;
+        color: #666;
 }
 
 /* Project detail */


### PR DESCRIPTION
## Summary
- show project start/end dates and progress on home page cards
- add styles for progress bars

## Testing
- `hugo --help` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e28401f24832aa5cae6a96a447b0e