### PR TITLE
Add task table to project

### DIFF
--- a/content/projects/alpha-project/_index.md
+++ b/content/projects/alpha-project/_index.md
@@ -6,3 +6,5 @@ date: 2025-05-20
 **Aplpha**
 
 {{< gantt >}}
+
+{{< task-table >}}

--- a/layouts/shortcodes/task-table.html
+++ b/layouts/shortcodes/task-table.html
@@ -1,0 +1,22 @@
+<table class="task-table">
+    <thead>
+        <tr>
+            <th>Task</th>
+            <th>Period</th>
+            <th>Status</th>
+            <th>Assignee</th>
+            <th>Priority</th>
+        </tr>
+    </thead>
+    <tbody>
+        {{ range sort .Page.Pages "Params.start" }}
+        <tr>
+            <td><a href="{{ .RelPermalink }}">{{ .Params.title }}</a></td>
+            <td>{{ .Params.start }} - {{ .Params.end }}</td>
+            <td>{{ .Params.status }}</td>
+            <td>{{ .Params.assignee }}</td>
+            <td>{{ .Params.priority }}</td>
+        </tr>
+        {{ end }}
+    </tbody>
+</table>

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -228,3 +228,21 @@ body {
         align-self: flex-start;
         padding: 0.5em 1em;
 }
+
+/* Task Table */
+.task-table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 1.5rem;
+}
+
+.task-table th,
+.task-table td {
+        padding: 0.5em;
+        border: 1px solid #e0e0e0;
+        text-align: left;
+}
+
+.task-table th {
+        background-color: #f0f0f0;
+}


### PR DESCRIPTION
## Summary
- add a `task-table` shortcode for listing tasks
- include this table on the Alpha Project page
- style the table in CSS

## Testing
- `hugo -D` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850c34d3288832a93ed0e851ee9b42a