### PR TITLE
Fix about and contact pages

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -17,12 +17,12 @@ title = "ProjectBoard"
     url = "/"
     weight = 1
   [[menu.main]]
-    identifier = "features"
+    identifier = "about"
     name = "about"
-    url = "/#features-section"
+    url = "/about/"
     weight = 2
   [[menu.main]]
     identifier = "contact"
     name = "contact"
-    url = "/#contact-section"
+    url = "/contact/"
     weight = 3

--- a/content/about.md
+++ b/content/about.md
@@ -1,0 +1,22 @@
+---
+title: "About"
+---
+
+<section class="home-features">
+## Features
+
+<div class="features-list">
+<div class="feature-item">
+### Task Management
+Keep track of project tasks with an easy Gantt view.
+</div>
+<div class="feature-item">
+### Priorities
+Visualize task priority and status at a glance.
+</div>
+<div class="feature-item">
+### Progress
+Monitor progress over time to stay on schedule.
+</div>
+</div>
+</section>

--- a/content/contact.md
+++ b/content/contact.md
@@ -1,0 +1,14 @@
+---
+title: "Contact"
+---
+
+<section class="contact-section">
+## Contact
+
+<form>
+<label>Name<br><input type="text" name="name"></label>
+<label>Email<br><input type="email" name="email"></label>
+<label>Message<br><textarea name="message"></textarea></label>
+<button type="submit">Send</button>
+</form>
+</section>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,0 +1,5 @@
+{{ define "main" }}
+<article class="page-content">
+    {{ .Content }}
+</article>
+{{ end }}

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -246,3 +246,8 @@ body {
 .task-table th {
         background-color: #f0f0f0;
 }
+
+/* Generic page styling */
+.page-content {
+        padding: 2em 0;
+}


### PR DESCRIPTION
## Summary
- add dedicated about and contact pages
- use a generic single page template
- style generic page content area
- update menu items to use new pages

## Testing
- `hugo --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850f33be194832a89c0735e21936f64