### PR TITLE
Fix alpha-project page visibility

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,7 @@
 baseURL = "https://cmdwolftech.gitlab.io/tasklist/"
 languageCode = "ja"
 title = "ProjectBoard"
+buildFuture = true
 
 [params]
   description = "sample"

--- a/content/projects/alpha-project/_index.md
+++ b/content/projects/alpha-project/_index.md
@@ -1,12 +1,12 @@
 ---
-title: "Alpa Project"
+title: "Alpha Project"
 date: 2025-05-20
 aliases:
   - /alpha-project/
 url: /alpha-project/
 ---
 
-**Aplpha**
+**Alpha**
 
 {{< gantt >}}
 


### PR DESCRIPTION
## Summary
- enable building future-dated content so `/projects/alpha-project` renders
- fix typos in Alpha Project index page

## Testing
- `hugo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685110784064832a8072155ae5fc2632