### PR TITLE
Add task summary counts

### DIFF
--- a/layouts/partials/task-count.html
+++ b/layouts/partials/task-count.html
@@ -1,0 +1,8 @@
+{{ $total := len .Pages }}
+{{ $completed := len (where .Pages "Params.status" "comp") }}
+{{ $remaining := sub $total $completed }}
+<div class="task-counts">
+    <span class="task-total">Total: {{ $total }}</span>
+    <span class="task-completed">Completed: {{ $completed }}</span>
+    <span class="task-remaining">Remaining: {{ $remaining }}</span>
+</div>

--- a/layouts/shortcodes/project-list.html
+++ b/layouts/shortcodes/project-list.html
@@ -24,6 +24,7 @@
             <div class="card-body">
                 <h3><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
                 <p class="project-dates">{{ $start }} - {{ $end }}</p>
+                {{ partial "task-count.html" . }}
                 {{ partial "gantt.html" . }}
             </div>
         </div>

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -251,3 +251,15 @@ body {
 .page-content {
         padding: 2em 0;
 }
+
+/* Task Counts */
+.task-counts {
+        display: flex;
+        gap: 0.5em;
+        font-size: 0.85rem;
+        margin: 0.5rem 0;
+        color: #666;
+}
+.task-counts span {
+        padding-right: 0.5em;
+}


### PR DESCRIPTION
## Summary
- show task counts for each project card in the project list
- add reusable partial `task-count.html`
- style the new task counts display

## Testing
- `hugo --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68515b568664832abcc26a7389c95dc3