### PR TITLE
Adjust single page layout

### DIFF
--- a/layouts/projects/single.html
+++ b/layouts/projects/single.html
@@ -4,7 +4,7 @@
 {{ $days := add 1 (div (sub ($end.Unix) ($start.Unix)) 86400) }}
 <div class="card task-details" id="task-details">
   <div class="task-details-header">
-    <div class="task-details-title">{{ .Title }}</div>
+    <h1 class="task-details-title">{{ .Title }}</h1>
     <div class="task-details-meta">
       <span class="status status-{{ if eq .Params.status "comp" }}completed{{ else if eq .Params.status "go" }}in-progress{{ else }}not-started{{ end }}">
         {{ if eq .Params.status "comp" }}完了{{ else if eq .Params.status "go" }}進行中{{ else }}未着手{{ end }}

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -263,3 +263,84 @@ body {
 .task-counts span {
         padding-right: 0.5em;
 }
+
+/* Task detail page */
+.task-details {
+        padding: 1.5rem;
+        margin-top: 2rem;
+}
+
+.task-details-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        margin-bottom: 1rem;
+}
+
+.task-details-title {
+        font-size: 1.5rem;
+        font-weight: bold;
+}
+
+.task-details-meta span {
+        display: inline-block;
+        margin-left: 0.5rem;
+        padding: 0.2rem 0.5rem;
+        border-radius: 4px;
+        font-size: 0.9rem;
+}
+
+.status-not-started {
+        background-color: #cccccc;
+        color: #fff;
+}
+.status-in-progress {
+        background-color: #f0ad4e;
+        color: #fff;
+}
+.status-completed {
+        background-color: #5cb85c;
+        color: #fff;
+}
+
+.priority-high {
+        background-color: #d9534f;
+        color: #fff;
+}
+.priority-medium {
+        background-color: #f0ad4e;
+        color: #fff;
+}
+.priority-low {
+        background-color: #5bc0de;
+        color: #fff;
+}
+
+.task-details-info {
+        display: flex;
+        gap: 1rem;
+        flex-wrap: wrap;
+        margin-bottom: 1rem;
+}
+
+.task-details-item {
+        flex: 1 1 150px;
+        background-color: #f7f7f7;
+        border: 1px solid #e0e0e0;
+        border-radius: 4px;
+        padding: 0.75rem;
+}
+
+.task-details-label {
+        font-size: 0.8rem;
+        color: #888;
+        margin-bottom: 0.25rem;
+}
+
+.task-details-value {
+        font-weight: bold;
+}
+
+.task-description {
+        margin-top: 1rem;
+}


### PR DESCRIPTION
## Summary
- tweak single task layout HTML
- add styles for task detail page

## Testing
- `hugo --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851660638ac832aba4827db044c0b66