### PR TITLE
Fix Gantt initialization

### DIFF
--- a/layouts/partials/gantt.html
+++ b/layouts/partials/gantt.html
@@ -15,7 +15,7 @@
         }{{ if lt (add $i 1) (len $.Pages) }}, {{ end }}
     {{- end }}
       ];
-  new Gantt(document.getElementById('{{ $gid }}'), tasks, { view_mode: 'Day', date_format: 'YYYY-MM-DD' });
+  new Gantt('#{{ $gid }}', tasks, { view_mode: 'Day', date_format: 'YYYY-MM-DD' });
     });
 </script>
 {{ else }}
@@ -35,7 +35,7 @@
         }{{ if lt (add $i 1) (len $all) }}, {{ end }}
       {{- end }}
     ];
-  new Gantt(document.getElementById('gantt-global'), tasks, { view_mode: 'Day', date_format: 'YYYY-MM-DD' });
+  new Gantt('#gantt-global', tasks, { view_mode: 'Day', date_format: 'YYYY-MM-DD' });
     });
 </script>
 {{ end }}


### PR DESCRIPTION
## Summary
- use selector strings when instantiating Frappe Gantt

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68517a261374832aa715ef00dd09f4f8