### PR TITLE
Add Fuse.js search

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3,6 +3,9 @@ languageCode = "ja"
 title = "ProjectBoard"
 buildFuture = true
 
+[outputs]
+  home = ["HTML", "JSON"]
+
 [params]
   description = "sample"
   logo_text = "Logo_text"

--- a/content/search.md
+++ b/content/search.md
@@ -1,0 +1,4 @@
+---
+title: "検索"
+layout: "search"
+---

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -14,8 +14,9 @@
 	<!-- Frappe Gantt JS -->
 	<script src="https://cdn.jsdelivr.net/npm/frappe-gantt/dist/frappe-gantt.min.js"></script>
 
-	<!-- Static CSS（static/ 配下にある場合） -->
-	<link rel="stylesheet" href="{{ "css/styles.css" | relURL }}">
+        <!-- Static CSS（static/ 配下にある場合） -->
+        <link rel="stylesheet" href="{{ "css/styles.css" | relURL }}">
+        <link rel="stylesheet" href="{{ "css/search.css" | relURL }}">
 
 </head>
 

--- a/layouts/_default/index.json
+++ b/layouts/_default/index.json
@@ -1,0 +1,9 @@
+[
+  {{- range .Site.RegularPages }}
+  {
+    "title": {{ .Title | jsonify }},
+    "permalink": {{ .Permalink | jsonify }},
+    "summary": {{ .Summary | plainify | jsonify }}
+  }{{ if not (last .) }},{{ end }}
+  {{- end }}
+]

--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -1,0 +1,33 @@
+<div class="search-container">
+  <input id="search-input" type="text" placeholder="検索..." class="search-box">
+  <ul id="search-results" class="search-results"></ul>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/fuse.js@6.6.2"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', async () => {
+    const res = await fetch('/index.json');
+    const data = await res.json();
+
+    const fuse = new Fuse(data, {
+      keys: ['title', 'summary'],
+      includeScore: true,
+      threshold: 0.3
+    });
+
+    const input = document.getElementById('search-input');
+    const resultsList = document.getElementById('search-results');
+
+    input.addEventListener('input', () => {
+      const query = input.value;
+      const results = fuse.search(query).slice(0, 10);
+
+      resultsList.innerHTML = '';
+      results.forEach(({ item }) => {
+        const li = document.createElement('li');
+        li.innerHTML = `<a href="${item.permalink}">${item.title}</a>`;
+        resultsList.appendChild(li);
+      });
+    });
+  });
+</script>

--- a/layouts/search.html
+++ b/layouts/search.html
@@ -1,0 +1,3 @@
+{{ define "main" }}
+  {{ partial "search.html" . }}
+{{ end }}

--- a/static/css/search.css
+++ b/static/css/search.css
@@ -1,0 +1,28 @@
+.search-container {
+  margin: 2rem auto;
+  max-width: 600px;
+  text-align: center;
+}
+.search-box {
+  width: 100%;
+  padding: 0.75rem;
+  font-size: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+.search-results {
+  list-style: none;
+  padding: 0;
+  margin-top: 1rem;
+  text-align: left;
+}
+.search-results li a {
+  display: block;
+  padding: 0.5rem;
+  border-bottom: 1px solid #eee;
+  text-decoration: none;
+  color: #333;
+}
+.search-results li a:hover {
+  background-color: #f5f5f5;
+}


### PR DESCRIPTION
## Summary
- include `index.json` output for search
- add Fuse.js search partial and page
- style search widget via `search.css`
- link search styles in base layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852c3066fb8832a9786e91390c70275