### PR TITLE
Fix search shortcode to display search bar

### DIFF
--- a/layouts/shortcodes/search.html
+++ b/layouts/shortcodes/search.html
@@ -1,3 +1,1 @@
-{{ define "main" }}
-  {{ partial "search.html" . }}
-{{ end }}
+{{ partial "search.html" . }}


### PR DESCRIPTION
## Summary
- remove incorrect block definition from the search shortcode so it outputs the search partial

## Testing
- `hugo -D` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853409afe20832aaed67b913cca1844