### PR TITLE
Fix search path for index.json

### DIFF
--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -6,7 +6,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/fuse.js/7.1.0/fuse.min.js"></script>
 <script>
   document.addEventListener('DOMContentLoaded', async () => {
-    const res = await fetch('/index.json');
+    const res = await fetch('{{ "index.json" | relURL }}');
     const data = await res.json();
 
     const fuse = new Fuse(data, {


### PR DESCRIPTION
## Summary
- fix search page to load the proper `index.json` URL

## Testing
- `hugo --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68534b4022f4832a9e15e291a8b84ecc