### PR TITLE
Fix Frappe Gantt initialization

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -10,9 +10,9 @@
         <link rel="icon" href="{{ "favicon.ico" | relURL }}">
 
 	<!-- Frappe Gantt -->
-	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/frappe-gantt/dist/frappe-gantt.css">
-	<!-- Frappe Gantt JS -->
-	<script src="https://cdn.jsdelivr.net/npm/frappe-gantt/dist/frappe-gantt.min.js"></script>
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/frappe-gantt@0.6.1/dist/frappe-gantt.css">
+        <!-- Frappe Gantt JS -->
+        <script src="https://cdn.jsdelivr.net/npm/frappe-gantt@0.6.1/dist/frappe-gantt.min.js"></script>
 
 	<!-- Static CSS（static/ 配下にある場合） -->
 	<link rel="stylesheet" href="{{ "css/styles.css" | relURL }}">


### PR DESCRIPTION
## Summary
- pin Frappe Gantt to v0.6.1 to avoid loading ES module

## Testing
- `hugo --minify` *(fails: hugo not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68534d3232f0832ab64155fe62887e51