### PR TITLE
Add language switcher to navigation

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -27,7 +27,17 @@
                 <nav class="main-nav">
                         <ul>
                                 {{ range .Site.Menus.main }}
+                                {{ if eq .Identifier "home" }}
+                                <li>
+                                        <select id="lang-switcher" onchange="location.href=this.value">
+                                                {{ range $.Site.Home.AllTranslations }}
+                                                <option value="{{ .RelPermalink }}" {{ if eq .Lang $.Site.Language.Lang }}selected{{ end }}>{{ .Language.LanguageName }}</option>
+                                                {{ end }}
+                                        </select>
+                                </li>
+                                {{ else }}
                                 <li><a href="{{ .URL | relURL }}">{{ .Name }}</a></li>
+                                {{ end }}
                                 {{ end }}
                                 <li id="today-date"></li>
                         </ul>

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -43,10 +43,18 @@ body {
 }
 
 .main-nav a {
-	text-decoration: none;
-	color: #555;
-	padding: 0.5em 1rem;
-	transition: background 0.3s;
+        text-decoration: none;
+        color: #555;
+        padding: 0.5em 1rem;
+        transition: background 0.3s;
+}
+
+.main-nav select {
+        padding: 0.5em 1rem;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        background: #fff;
+        margin-right: 0.5rem;
 }
 
 .main-nav a:hover {


### PR DESCRIPTION
## Summary
- modify main navigation so that the "Home" slot becomes a language dropdown
- add styles for the dropdown menu

## Testing
- `hugo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685401578aec832a83d2573d85b746c4