### PR TITLE
Add responsive mobile menu

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -24,8 +24,9 @@
 	<header class="site-header">
 		<div class="container header-inner">
 			<h1 class="logo"><a href="{{ "" | absURL }}">{{ .Site.Title }}</a></h1>
-                <nav class="main-nav">
-                        <ul>
+               <nav class="main-nav">
+                       <button id="menu-toggle" class="menu-toggle" aria-label="メニュー">&#x22EE;</button>
+                       <ul>
                                 {{ range .Site.Menus.main }}
                                 {{ if eq .Identifier "home" }}
                                 <li>
@@ -49,7 +50,8 @@
 		{{ block "main" . }}{{ end }}
 	</main>
 
-	<script src="{{ "js/today-jst.js" | relURL }}" defer></script>
+       <script src="{{ "js/today-jst.js" | relURL }}" defer></script>
+       <script src="{{ "js/menu-toggle.js" | relURL }}" defer></script>
 
 	<footer class="site-footer">
 		<div class="container">

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -57,9 +57,41 @@ body {
         margin-right: 0.5rem;
 }
 
+.menu-toggle {
+        display: none;
+        background: none;
+        border: none;
+        font-size: 1.5rem;
+        padding: 0.5em;
+        cursor: pointer;
+}
+
 .main-nav a:hover {
-	background-color: #efefef;
-	border-radius: 4px;
+        background-color: #efefef;
+        border-radius: 4px;
+}
+
+@media (max-width: 960px) {
+        .main-nav ul {
+                position: fixed;
+                top: 0;
+                right: -250px;
+                width: 200px;
+                height: 100%;
+                background: #ffffff;
+                flex-direction: column;
+                padding: 1em;
+                box-shadow: -2px 0 5px rgba(0,0,0,0.1);
+                transition: right 0.3s;
+        }
+
+        .main-nav ul.open {
+                right: 0;
+        }
+
+        .menu-toggle {
+                display: block;
+        }
 }
 
 /* Project Card */

--- a/static/js/menu-toggle.js
+++ b/static/js/menu-toggle.js
@@ -1,0 +1,8 @@
+document.addEventListener('DOMContentLoaded', function () {
+  var toggle = document.getElementById('menu-toggle');
+  var menu = document.querySelector('.main-nav ul');
+  if (!toggle || !menu) return;
+  toggle.addEventListener('click', function () {
+    menu.classList.toggle('open');
+  });
+});


### PR DESCRIPTION
## Summary
- add three-dot toggle button for menu
- implement slide-in menu styles
- add menu toggle script

## Testing
- `hugo version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68547c626a54832a998f15ccd9b0683e