### PR TITLE
Fix mobile menu closing and layering

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -83,6 +83,7 @@ body {
                 padding: 1em;
                 box-shadow: -2px 0 5px rgba(0,0,0,0.1);
                 transition: right 0.3s;
+                z-index: 1000;
         }
 
         .main-nav ul.open {
@@ -91,6 +92,8 @@ body {
 
         .menu-toggle {
                 display: block;
+                position: relative;
+                z-index: 1001;
         }
 }
 

--- a/static/js/menu-toggle.js
+++ b/static/js/menu-toggle.js
@@ -2,7 +2,21 @@ document.addEventListener('DOMContentLoaded', function () {
   var toggle = document.getElementById('menu-toggle');
   var menu = document.querySelector('.main-nav ul');
   if (!toggle || !menu) return;
-  toggle.addEventListener('click', function () {
+
+  function closeOnClickOutside(e) {
+    if (!menu.contains(e.target) && e.target !== toggle) {
+      menu.classList.remove('open');
+      document.removeEventListener('click', closeOnClickOutside);
+    }
+  }
+
+  toggle.addEventListener('click', function (e) {
+    e.stopPropagation();
     menu.classList.toggle('open');
+    if (menu.classList.contains('open')) {
+      document.addEventListener('click', closeOnClickOutside);
+    } else {
+      document.removeEventListener('click', closeOnClickOutside);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- allow closing the responsive menu by clicking outside or on the toggle
- ensure the mobile menu overlays the Gantt chart and keep the toggle accessible

## Testing
- `hugo -D` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68548f961c40832aafd8e317b4055252