### PR TITLE
Update mobile nav layout

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -27,6 +27,9 @@
                <nav class="main-nav">
                        <button id="menu-toggle" class="menu-toggle" aria-label="メニュー">&#x22EE;</button>
                        <ul>
+                                <li class="menu-close-item">
+                                        <button id="menu-close" class="menu-close" aria-label="メニューを閉じる">&times;</button>
+                                </li>
                                 <li>
                                         <select id="lang-switcher" onchange="location.href=this.value">
                                         {{ range $.Site.Home.AllTranslations }}

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -66,6 +66,17 @@ body {
         cursor: pointer;
 }
 
+.menu-close {
+        display: none;
+        background: none;
+        border: none;
+        font-size: 1.5rem;
+        padding: 0.5em;
+        cursor: pointer;
+        width: 100%;
+        text-align: right;
+}
+
 .main-nav a:hover {
         background-color: #efefef;
         border-radius: 4px;
@@ -94,6 +105,9 @@ body {
                 display: block;
                 position: relative;
                 z-index: 1001;
+        }
+        .menu-close {
+                display: block;
         }
 }
 

--- a/static/js/menu-toggle.js
+++ b/static/js/menu-toggle.js
@@ -1,13 +1,17 @@
 document.addEventListener('DOMContentLoaded', function () {
   var toggle = document.getElementById('menu-toggle');
   var menu = document.querySelector('.main-nav ul');
+  var closeBtn = document.getElementById('menu-close');
   if (!toggle || !menu) return;
+
+  function closeMenu() {
+    menu.classList.remove('open');
+    document.removeEventListener('click', closeOnClickOutside);
+  }
 
   function closeOnClickOutside(e) {
     if (!menu.contains(e.target) && e.target !== toggle) {
-      menu.classList.remove('open');
-      toggle.innerHTML = '&#x22EE;'; // 元に戻す
-      document.removeEventListener('click', closeOnClickOutside);
+      closeMenu();
     }
   }
 
@@ -15,11 +19,15 @@ document.addEventListener('DOMContentLoaded', function () {
     e.stopPropagation();
     menu.classList.toggle('open');
     if (menu.classList.contains('open')) {
-      toggle.innerHTML = '&times;'; // ✗ に変更
       document.addEventListener('click', closeOnClickOutside);
     } else {
-      toggle.innerHTML = '&#x22EE;'; // 三点リーダーに戻す
       document.removeEventListener('click', closeOnClickOutside);
     }
   });
+
+  if (closeBtn) {
+    closeBtn.addEventListener('click', function () {
+      closeMenu();
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- add a close button inside the mobile navigation menu
- keep ellipsis button in place and show a new close button at the top of the menu
- update JS to handle new button
- tweak styles for `.menu-close`

## Testing
- `hugo --minify` *(fails: command not found)*
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685723534bc8832a9a1cd0e17be879e0