### PR TITLE
Fix mobile nav toggle display

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -97,6 +97,22 @@ body {
                 z-index: 1000;
         }
 
+        .menu-close-item {
+                position: absolute;
+                top: 50%;
+                left: 0;
+                width: 100%;
+                transform: translateY(-50%);
+                text-align: center;
+        }
+
+        .menu-close {
+                display: block;
+                width: auto;
+                text-align: center;
+                z-index: 1001;
+        }
+
         .main-nav ul.open {
                 right: 0;
         }
@@ -105,9 +121,6 @@ body {
                 display: block;
                 position: relative;
                 z-index: 1001;
-        }
-        .menu-close {
-                display: block;
         }
 }
 

--- a/static/js/menu-toggle.js
+++ b/static/js/menu-toggle.js
@@ -6,6 +6,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   function closeMenu() {
     menu.classList.remove('open');
+    if (toggle) toggle.style.display = '';
     document.removeEventListener('click', closeOnClickOutside);
   }
 
@@ -19,8 +20,10 @@ document.addEventListener('DOMContentLoaded', function () {
     e.stopPropagation();
     menu.classList.toggle('open');
     if (menu.classList.contains('open')) {
+      toggle.style.display = 'none';
       document.addEventListener('click', closeOnClickOutside);
     } else {
+      toggle.style.display = '';
       document.removeEventListener('click', closeOnClickOutside);
     }
   });


### PR DESCRIPTION
## Summary
- center the mobile close button inside the menu
- hide the ellipsis toggle when the menu is open

## Testing
- `hugo version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857314359f4832ab9552a31140092c6