### PR TITLE
Fix mobile menu close button overlap

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -98,11 +98,9 @@ body {
         }
 
         .menu-close-item {
-                position: absolute;
-                left: 0;
                 width: 100%;
-                transform: translateY(-50%);
                 text-align: center;
+                margin-bottom: 1em;
         }
 
         .menu-close {


### PR DESCRIPTION
## Summary
- fix the close button position in the mobile nav

## Testing
- `hugo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68573d632bd4832a9781a89470a20110