### PR TITLE
Add tag filtering in search

### DIFF
--- a/layouts/_default/index.json
+++ b/layouts/_default/index.json
@@ -4,7 +4,8 @@
   {
     "title": {{ $element.Title | jsonify }},
     "permalink": {{ $element.Permalink | jsonify }},
-    "summary": {{ $element.Summary | plainify | jsonify}}
+    "summary": {{ $element.Summary | plainify | jsonify}},
+    "tags": {{ $element.Params.tags | jsonify }}
   }{{ if lt (add $index 1) (len $pages) }},{{ end }}
 {{- end }}
 ]

--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -1,5 +1,6 @@
 <div class="search-container">
   <input id="search-input" type="text" placeholder="{{ i18n "searchLabel" }}" class="search-box">
+  <div id="tag-list" class="tag-list"></div>
   <ul id="search-results" class="search-results"></ul>
 </div>
 
@@ -17,17 +18,39 @@
 
     const input = document.getElementById('search-input');
     const resultsList = document.getElementById('search-results');
+    const tagList = document.getElementById('tag-list');
 
-    input.addEventListener('input', () => {
-      const query = input.value;
-      const results = fuse.search(query).slice(0, 10);
-
+    function renderResults(items) {
       resultsList.innerHTML = '';
-      results.forEach(({ item }) => {
+      items.forEach((item) => {
         const li = document.createElement('li');
         li.innerHTML = `<a href="${item.permalink}">${item.title}</a>`;
         resultsList.appendChild(li);
       });
+    }
+
+    const tags = new Set();
+    data.forEach(page => {
+      if (page.tags) {
+        page.tags.forEach(tag => tags.add(tag));
+      }
+    });
+
+    tags.forEach(tag => {
+      const span = document.createElement('span');
+      span.className = 'tag';
+      span.textContent = tag;
+      span.addEventListener('click', () => {
+        const filtered = data.filter(page => page.tags && page.tags.includes(tag));
+        renderResults(filtered);
+      });
+      tagList.appendChild(span);
+    });
+
+    input.addEventListener('input', () => {
+      const query = input.value;
+      const results = fuse.search(query).slice(0, 10).map(r => r.item);
+      renderResults(results);
     });
   });
 </script>

--- a/static/css/search.css
+++ b/static/css/search.css
@@ -26,3 +26,19 @@
 .search-results li a:hover {
   background-color: #f5f5f5;
 }
+
+.tag-list {
+  margin-top: 1rem;
+  text-align: left;
+}
+
+.tag-list .tag {
+  display: inline-block;
+  background-color: #e7e7e7;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 0.1rem 0.4rem;
+  margin: 0 0.25rem 0.25rem 0;
+  font-size: 0.8rem;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- include tags in `index.json`
- enhance search partial to display tags and filter results
- style tag list on search page

## Testing
- `hugo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bef0c3cfc832a9cde1d9b43b96fb9