### PR TITLE
Add parent-child task display

### DIFF
--- a/content/en/projects/alpha-project/task-1.md
+++ b/content/en/projects/alpha-project/task-1.md
@@ -5,6 +5,7 @@ end: "2025-05-23"
 status: "completed"
 assignee: "sato"
 priority: "High"
+parent: "task-2"
 tags:
   - initial
   - alpha

--- a/content/ja/projects/alpha-project/task-1.md
+++ b/content/ja/projects/alpha-project/task-1.md
@@ -5,6 +5,7 @@ end: "2025-05-23"
 status: "completed"
 assignee: "sato"
 priority: "High"
+parent: "task-2"
 tags:
   - initial
   - alpha

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -43,3 +43,7 @@
   translation: "Last Updated"
 - id: Tags
   translation: "Tags"
+- id: ParentTask
+  translation: "Parent Task"
+- id: ChildTasks
+  translation: "Child Tasks"

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -43,3 +43,7 @@
   translation: "最終更新日"
 - id: Tags
   translation: "タグ"
+- id: ParentTask
+  translation: "親タスク"
+- id: ChildTasks
+  translation: "子タスク"

--- a/layouts/projects/single.html
+++ b/layouts/projects/single.html
@@ -52,6 +52,32 @@
       </div>
     </div>
     {{ end }}
+    {{ with .Params.parent }}
+    {{ $parent := $.CurrentSection.GetPage . }}
+    <div class="task-details-item">
+      <div class="task-details-label">{{ i18n "ParentTask" }}</div>
+      <div class="task-details-value">
+        {{ if $parent }}
+          <a href="{{ $parent.RelPermalink }}">{{ $parent.Title }}</a>
+        {{ else }}
+          {{ . }}
+        {{ end }}
+      </div>
+    </div>
+    {{ end }}
+    {{ $children := where $.CurrentSection.Pages "Params.parent" $.File.BaseFileName }}
+    {{ if gt (len $children) 0 }}
+    <div class="task-details-item">
+      <div class="task-details-label">{{ i18n "ChildTasks" }}</div>
+      <div class="task-details-value">
+        <ul>
+          {{ range $children }}
+          <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+          {{ end }}
+        </ul>
+      </div>
+    </div>
+    {{ end }}
   </div>
   <div class="task-description">
     {{ .Content }}


### PR DESCRIPTION
## Summary
- support linking tasks to their parent task and listing child tasks
- localize labels for parent and child tasks
- mark task-1 as a child of task-2 in both languages

## Testing
- `hugo --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bf3674274832ab26a75f36899d466