### PR TITLE
Add configurable profile image on about pages

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -12,6 +12,7 @@ enableGitInfo = true
   description = "sample"
   logo_text = "Logo_text"
   copyLight = "2025 ProjectBoard. Made with"
+  profile_image = "profile.jpg"
 
   [params.social]
     twitter  = "https://twitter.com/yourhandle"

--- a/content/en/about.md
+++ b/content/en/about.md
@@ -2,6 +2,14 @@
 title: "About"
 ---
 
+{{ $profileName := .Site.Params.profile_image | default "profile.jpg" }}
+{{ $profile := printf "static/img/%s" $profileName }}
+{{ if fileExists $profile }}
+<div class="profile-wrapper">
+  <img src="{{ printf "img/%s" $profileName | relURL }}" alt="Profile Photo" class="profile-photo">
+</div>
+{{ end }}
+
 ## Features
 
 <div class="features-list">

--- a/content/ja/about.md
+++ b/content/ja/about.md
@@ -2,6 +2,14 @@
 title: "概要"
 ---
 
+{{ $profileName := .Site.Params.profile_image | default "profile.jpg" }}
+{{ $profile := printf "static/img/%s" $profileName }}
+{{ if fileExists $profile }}
+<div class="profile-wrapper">
+  <img src="{{ printf "img/%s" $profileName | relURL }}" alt="プロフィール画像" class="profile-photo">
+</div>
+{{ end }}
+
 ## 機能
 
 <div class="features-list">

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -452,3 +452,17 @@ body {
 .social-icons a:hover .icon {
         opacity: 0.6;
 }
+
+/* Profile Photo */
+.profile-wrapper {
+        display: flex;
+        justify-content: center;
+        margin: 1rem 0;
+}
+
+.profile-photo {
+        width: 200px;
+        height: 200px;
+        object-fit: cover;
+        border-radius: 50%;
+}


### PR DESCRIPTION
## Summary
- add `profile_image` param in config
- load profile image filename from config on about pages

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685bfc411580832a80418bc8b3b7c53f