### PR TITLE
Enable sitemap output

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -6,7 +6,12 @@ defaultContentLanguageInSubdir = true
 enableGitInfo = true
 
 [outputs]
-  home = ["HTML", "JSON"]
+  home = ["HTML", "JSON", "SITEMAP"]
+
+[sitemap]
+  changefreq = "monthly"
+  priority = 0.5
+  filename = "sitemap.xml"
 
 [params]
   description = "sample"


### PR DESCRIPTION
## Summary
- generate Hugo sitemap for the site

## Testing
- `hugo version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c03da11a4832ab7a2a8c49ca19963