### PR TITLE
Add dynamic robots.txt generation

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -6,7 +6,7 @@ defaultContentLanguageInSubdir = true
 enableGitInfo = true
 
 [outputs]
-  home = ["HTML", "JSON", "SITEMAP"]
+  home = ["HTML", "JSON", "SITEMAP", "ROBOTS"]
 
 [sitemap]
 #  changefreq = "monthly"

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,0 +1,11 @@
+{{- $host := replaceRE "^https?://([^/]+)/?.*$" "$1" .Site.BaseURL -}}
+User-agent: *
+Allow: /
+
+Disallow: /search/
+{{- range .Site.Languages }}
+Disallow: /{{ .Lang }}/search/
+{{- end }}
+
+Host: {{ $host }}
+Sitemap: {{ .Site.BaseURL }}sitemap.xml


### PR DESCRIPTION
## Summary
- generate a `robots.txt` using Hugo templates
- enable the `ROBOTS` output format in the Hugo config

## Testing
- `hugo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c6af4b99c832ab60704ac4476ae9a