### PR TITLE
Add metadata partial for social tags

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,9 +2,10 @@
 <html lang="{{ .Site.LanguageCode | default "ja" }}">
 
 <head>
-	<meta charset="UTF-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}</title>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        {{ partial "metadata.html" . }}
+        <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}</title>
 
 	<!-- Favicon -->
         <link rel="icon" href="{{ "favicon.ico" | relURL }}">

--- a/layouts/partials/metadata.html
+++ b/layouts/partials/metadata.html
@@ -1,0 +1,23 @@
+{{ $title := cond .IsHome .Site.Title (printf "%s | %s" .Title .Site.Title) }}
+{{ $description := .Params.description | default .Site.Params.description }}
+{{ $type := cond (or .IsHome .IsSection) "website" "article" }}
+{{ $url := .Permalink }}
+{{ $image := "" }}
+{{ with .Params.images }}
+  {{ $image = (index . 0) | absURL }}
+{{ else }}
+  {{ with .Site.Params.profile_image }}
+    {{ $image = printf "img/%s" . | absURL }}
+  {{ end }}
+{{ end }}
+
+{{ if $title }}<meta property="og:title" content="{{ $title }}">{{ end }}
+{{ if $description }}<meta property="og:description" content="{{ $description }}">{{ end }}
+<meta property="og:url" content="{{ $url }}">
+{{ if $type }}<meta property="og:type" content="{{ $type }}">{{ end }}
+{{ if $image }}<meta property="og:image" content="{{ $image }}">{{ end }}
+
+<meta name="twitter:card" content="summary_large_image">
+{{ if $title }}<meta name="twitter:title" content="{{ $title }}">{{ end }}
+{{ if $description }}<meta name="twitter:description" content="{{ $description }}">{{ end }}
+{{ if $image }}<meta name="twitter:image" content="{{ $image }}">{{ end }}


### PR DESCRIPTION
## Summary
- add `metadata.html` partial that outputs Open Graph and Twitter Card meta tags
- include the new partial in the site's `baseof.html`

## Testing
- `hugo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c6d0399bc832a81793a01eed8530b