### PR TITLE
Enable robots.txt via config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -4,6 +4,7 @@ buildFuture = true
 defaultContentLanguage = "ja"
 defaultContentLanguageInSubdir = true
 enableGitInfo = true
+enableRobotsTXT = true
 
 [outputs]
   home = ["HTML", "JSON", "SITEMAP", "ROBOTS"]
@@ -14,6 +15,7 @@ enableGitInfo = true
   filename = "sitemap.xml"
 
 [params]
+  enableRobotsTXT = true
   description = "sample"
   logo_text = "Logo_text"
   copyLight = "2025 ProjectBoard. Made with"

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,3 +1,4 @@
+{{- if .Site.Params.enableRobotsTXT -}}
 {{- $host := replaceRE "^https?://([^/]+)/?.*$" "$1" .Site.BaseURL -}}
 User-agent: *
 Allow: /
@@ -9,3 +10,4 @@ Disallow: /{{ .Lang }}/search/
 
 Host: {{ $host }}
 Sitemap: {{ .Site.BaseURL }}sitemap.xml
+{{- end -}}


### PR DESCRIPTION
## Summary
- generate `robots.txt` by default
- gate template output on `enableRobotsTXT`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c704a6cc4832a9d4a4a6fd4097b2e