### PR TITLE
Add meta tags and Google Analytics

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -5,6 +5,7 @@ defaultContentLanguage = "ja"
 defaultContentLanguageInSubdir = true
 enableGitInfo = true
 enableRobotsTXT = true
+googleAnalytics = "G-XXXXXXXXXX"
 
 [outputs]
   home = ["HTML", "JSON", "SITEMAP", "ROBOTS"]
@@ -20,6 +21,8 @@ enableRobotsTXT = true
   logo_text = "Logo_text"
   copyLight = "2025 ProjectBoard. Made with"
   profile_image = "profile.png"
+  author = "あなたの名前"
+  keywords = ["キーワード1", "キーワード2", "キーワード3"]
 
   [params.social]
     twitter  = "https://twitter.com/yourhandle"

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -16,9 +16,9 @@
         <script src="https://cdn.jsdelivr.net/npm/frappe-gantt@0.6.1/dist/frappe-gantt.min.js"></script>
 
 	<!-- Static CSS（static/ 配下にある場合） -->
-	<link rel="stylesheet" href="{{ "css/styles.css" | relURL }}">
-	<link rel="stylesheet" href="{{ "css/search.css" | relURL }}">
-
+        <link rel="stylesheet" href="{{ "css/styles.css" | relURL }}">
+        <link rel="stylesheet" href="{{ "css/search.css" | relURL }}">
+        {{ template "_internal/google_analytics.html" . }}
 </head>
 
 <body>

--- a/layouts/partials/metadata.html
+++ b/layouts/partials/metadata.html
@@ -18,6 +18,9 @@
   {{ if $image }}<meta property="og:image" content="{{ $image }}">{{ end }}
 {{ end }}
 
+{{ with .Site.Params.author }}<meta name="author" content="{{ . }}">{{ end }}
+{{ with .Site.Params.keywords }}<meta name="keywords" content="{{ delimit . ", " }}">{{ end }}
+
 {{ if .Site.Params.twitter_cards.enable }}
   <meta name="twitter:card" content="summary_large_image">
   {{ with .Site.Params.twitter_cards.site }}<meta name="twitter:site" content="{{ . }}">{{ end }}


### PR DESCRIPTION
## Summary
- improve SEO metadata with author and keywords
- set up Google Analytics in Hugo config and layout

## Testing
- `hugo --source . --destination public` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c72d4675c832aa97ee2010f84882b