### PR TITLE
Fix metadata partial syntax

### DIFF
--- a/layouts/partials/metadata.html
+++ b/layouts/partials/metadata.html
@@ -6,8 +6,10 @@
 {{ $image := "" }}
 {{ with .Params.images }}
   {{ $image = (index . 0) | absURL }}
-{{ else if $imageParam }}
-  {{ $image = printf "img/%s" $imageParam | absURL }}
+{{ else }}
+  {{ if $imageParam }}
+    {{ $image = printf "img/%s" $imageParam | absURL }}
+  {{ end }}
 {{ end }}
 
 {{ if .Site.Params.opengraph.enable }}


### PR DESCRIPTION
## Summary
- correct else-if logic in `layouts/partials/metadata.html`

## Testing
- `hugo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c74293e10832aa84823dcfaf3a346