### PR TITLE
Fix social icons shortcode

### DIFF
--- a/layouts/shortcodes/social-icons.html
+++ b/layouts/shortcodes/social-icons.html
@@ -1,6 +1,6 @@
-{{ $social := site.Params.social }}
+{{ $social := .Site.Params.social }}
 {{ $links := slice }}
-{{ range site.Data.social.social_icons }}
+{{ range .Site.Data.social.social_icons }}
   {{ $handle := index $social .id }}
   {{ if $handle }}
     {{ $url := cond (or (hasPrefix $handle "http://") (hasPrefix $handle "https://")) $handle (printf .url $handle) }}


### PR DESCRIPTION
## Summary
- fix social icons shortcode to reference `.Site` correctly

## Testing
- `hugo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d65277334832aa89594e504c73aa4