### PR TITLE
Fix social icons shortcode

### DIFF
--- a/layouts/shortcodes/social-icons.html
+++ b/layouts/shortcodes/social-icons.html
@@ -1,10 +1,11 @@
 {{ $social := .Site.Params.social }}
 {{ $links := slice }}
 {{ range .Site.Data.social.social_icons }}
-  {{ $handle := index $social .id }}
+  {{ $id := index . "id" }}
+  {{ $handle := index $social $id }}
   {{ if $handle }}
     {{ $url := cond (or (hasPrefix $handle "http://") (hasPrefix $handle "https://")) $handle (printf .url $handle) }}
-    {{ $links = $links | append (dict "key" .id "url" $url) }}
+    {{ $links = $links | append (dict "key" $id "url" $url) }}
   {{ end }}
 {{ end }}
 {{ if gt (len $links) 0 }}


### PR DESCRIPTION
## Summary
- fix field access in social-icons shortcode

## Testing
- `hugo --gc --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d66cc5a50832aab244169eb166618