### PR TITLE
Fix social icons shortcode

### DIFF
--- a/layouts/shortcodes/social-icons.html
+++ b/layouts/shortcodes/social-icons.html
@@ -1,7 +1,7 @@
 {{ $social := .Site.Params.social }}
 {{ $links := slice }}
 {{ range .Site.Data.social.social_icons }}
-  {{ $id := index . "id" }}
+  {{ $id := .id }}
   {{ $handle := index $social $id }}
   {{ if $handle }}
     {{ $url := cond (or (hasPrefix $handle "http://") (hasPrefix $handle "https://")) $handle (printf .url $handle) }}


### PR DESCRIPTION
## Summary
- use `.id` property when iterating over social icons data

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685d685d5234832ab35c4549be64dfb0