### PR TITLE
Fix social-icons shortcode data access

### DIFF
--- a/layouts/shortcodes/social-icons.html
+++ b/layouts/shortcodes/social-icons.html
@@ -1,7 +1,7 @@
 {{ $social := .Site.Params.social }}
 {{ $links := slice }}
 {{ range .Site.Data.social.social_icons }}
-  {{ $id := .id }}
+  {{ $id := index . "id" }}
   {{ $handle := index $social $id }}
   {{ if $handle }}
     {{ $url := cond (or (hasPrefix $handle "http://") (hasPrefix $handle "https://")) $handle (printf .url $handle) }}


### PR DESCRIPTION
## Summary
- fix field access for social icons shortcode to avoid rendering errors

## Testing
- `hugo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d69f778f8832a9215bd7c5154e5c2