### PR TITLE
Fix social-icons shortcode

### DIFF
--- a/layouts/shortcodes/social-icons.html
+++ b/layouts/shortcodes/social-icons.html
@@ -1,7 +1,7 @@
 {{ $social := .Site.Params.social }}
 {{ $links := slice }}
 {{ range .Site.Data.social.social_icons }}
-  {{ $id := index . "id" }}
+  {{ $id := .id }}
   {{ $handle := index $social $id }}
   {{ if $handle }}
     {{ $url := cond (or (hasPrefix $handle "http://") (hasPrefix $handle "https://")) $handle (printf .url $handle) }}


### PR DESCRIPTION
## Summary
- fix extraction of `id` in the social-icons shortcode

## Testing
- `hugo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d6dc5271c832a8c62f55772607b12