### PR TITLE
Fix social icon rendering

### DIFF
--- a/layouts/shortcodes/social-icons.html
+++ b/layouts/shortcodes/social-icons.html
@@ -1,11 +1,19 @@
+{{ $social := .Site.Params.social }}
+{{ $links := slice }}
 {{ range .Site.Data.social.social_icons }}
-  {{- if isset $.Site.Params.social .id }}
-  {{ if or ( hasPrefix ( index $.Site.Params.social .id ) "http://" ) ( hasPrefix ( index $.Site.Params.social .id ) "https://" ) }}
-<a href="{{ printf "%s" (index $.Site.Params.social .id) }}" target="_blank" rel="noopener noreferrer" aria-label="{{ .title }}">
-  {{ else }}
-  <a href="{{ printf .url (index $.Site.Params.social .id) }}" target="_blank" rel="noopener noreferrer" aria-label="{{ .title }}">
+  {{ $id := .id }}
+  {{ $handle := index $social $id }}
+  {{ if $handle }}
+    {{ $url := cond (or (hasPrefix $handle "http://") (hasPrefix $handle "https://")) $handle (printf .url $handle) }}
+    {{ $links = $links | append (dict "key" $id "url" $url) }}
   {{ end }}
-  <img src="{{ printf "icons/%s.svg" (index $.Site.Params.social .id) | relURL }}" alt="{{ .title }} icon" class="icon">
-</a>
-{{- end -}}
+{{ end }}
+{{ if gt (len $links) 0 }}
+<div class="social-icons">
+  {{ range $links }}
+    <a href="{{ .url }}" target="_blank" rel="noopener noreferrer" aria-label="{{ .key }}">
+      <img src="{{ printf "icons/%s.svg" .key | relURL }}" alt="{{ .key }} icon" class="icon">
+    </a>
+  {{ end }}
+</div>
 {{ end }}


### PR DESCRIPTION
## Summary
- correct id usage in the social-icons shortcode
- wrap generated icons in `.social-icons` container

## Testing
- `hugo --minify -s .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ddd26ec30832aa68268e28afa0c09