### PR TITLE
Fix social icons shortcode for old Hugo versions

### DIFF
--- a/layouts/shortcodes/social-icons.html
+++ b/layouts/shortcodes/social-icons.html
@@ -1,5 +1,9 @@
 {{ $social := .Site.Params.social }}
-{{ $icons := where .Site.Data.social.social_icons "id" "in" (keys $social) }}
+{{ $keys := slice }}
+{{ range $k, $_ := $social }}
+  {{ $keys = $keys | append $k }}
+{{ end }}
+{{ $icons := where .Site.Data.social.social_icons "id" "in" $keys }}
 {{ if gt (len $icons) 0 }}
 <div class="social-icons">
   {{ range $icons }}


### PR DESCRIPTION
## Summary
- avoid `keys` template function for compatibility with Hugo versions that lack it

## Testing
- `hugo --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685de217ed3c832a958b033d0f71522b