### PR TITLE
Fix member bio rendering

### DIFF
--- a/layouts/partials/member.html
+++ b/layouts/partials/member.html
@@ -13,7 +13,7 @@
           {{ end }}
         {{ end }}
         <h3>{{ .Title }}</h3>
-        <div class="member-bio">{{ .Content | markdownify }}</div>
+        <div class="member-bio">{{ .Content }}</div>
       </div>
     {{ end }}
   </div>


### PR DESCRIPTION
## Summary
- ensure member bio text renders correctly by removing an unnecessary `markdownify` call in the member partial

## Testing
- `hugo --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685def466720832a8055dd6aff52c5e7