### PR TITLE
Fix back link on project list page

### DIFF
--- a/layouts/projects/list.html
+++ b/layouts/projects/list.html
@@ -5,6 +5,6 @@
         {{ partial "task-table.html" . }}
 </section>
 <div class="back-link">
-        <a href="{{ "/" | relURL }}">&larr; {{ i18n "Back"}}</a>
+        <a href="{{ "/" | relLangURL }}">&larr; {{ i18n "Back"}}</a>
 </div>
 {{ end }}


### PR DESCRIPTION
## Summary
- adjust language-relative `Back` link in `layouts/projects/list.html`

## Testing
- `hugo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e4198cafc832a9e9e2a6118f7aaa5