### PR TITLE
Fix back link on project list page

### DIFF
--- a/layouts/projects/list.html
+++ b/layouts/projects/list.html
@@ -5,6 +5,6 @@
         {{ partial "task-table.html" . }}
 </section>
 <div class="back-link">
-        <a href="{{ "/" | relURL }}">&larr; {{ i18n "Back"}}</a>
+        <a href="{{ "" | absLangURL }}">&larr; {{ i18n "Back"}}</a>
 </div>
 {{ end }}


### PR DESCRIPTION
## Summary
- update back link in `layouts/projects/list.html` to use `absLangURL`

## Testing
- `hugo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e4198cafc832a9e9e2a6118f7aaa5