### PR TITLE
Improve blog list layout

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -51,3 +51,5 @@
   translation: "Published"
 - id: Blog
   translation: "Blog"
+- id: ReadMore
+  translation: "Read more"

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -51,3 +51,5 @@
   translation: "作成日"
 - id: Blog
   translation: "ブログ"
+- id: ReadMore
+  translation: "続きを読む"

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -8,9 +8,17 @@
     {{ range .Pages }}
       <article class="blog-item">
         <h3><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
-        {{ if $.Site.Params.blog.showDates }}
-          <p class="date">{{ .Date.Format "2006-01-02" }}</p>
-        {{ end }}
+        <div class="meta">
+          {{ if $.Site.Params.blog.showDates }}
+            <span class="date">{{ .Date.Format "2006-01-02" }}</span>
+          {{ end }}
+          {{ with .Params.tags }}{{ if $.Site.Params.blog.showTags }}
+            <span class="tags">
+              {{ range $index, $tag := . }}<span class="tag">{{ $tag }}</span>{{ end }}
+            </span>
+          {{ end }}{{ end }}
+        </div>
+        <p class="read-more"><a href="{{ .RelPermalink }}">{{ i18n "ReadMore" }}</a></p>
       </article>
     {{ end }}
   </div>

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -578,6 +578,28 @@ body {
         color: #666;
 }
 
+.blog-item .meta {
+        margin-bottom: 0.5rem;
+        font-size: 0.9rem;
+        color: #666;
+}
+
+.blog-item .meta .tag {
+        margin-right: 0.25rem;
+}
+
+.blog-item .read-more a {
+        display: inline-block;
+        margin-top: 0.25rem;
+        color: #007bff;
+        text-decoration: none;
+        font-weight: bold;
+}
+
+.blog-item .read-more a:hover {
+        text-decoration: underline;
+}
+
 .blog-item a {
         text-decoration: none;
         color: #333;


### PR DESCRIPTION
## Summary
- add `ReadMore` translation for English and Japanese
- show dates and tags on blog list
- add a Read more link on the blog list
- style blog list metadata and link

## Testing
- `hugo --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687649b09f94832a8443cdffe94d9508