### PR TITLE
Fix blog post alignment

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -614,6 +614,7 @@ body {
 .blog-post {
         margin: 0 auto 2rem;
         max-width: 800px;
+        text-align: left;
 }
 
 .blog-post .post-header {


### PR DESCRIPTION
## Summary
- ensure single blog posts render left-aligned text but remain centered on the page

## Testing
- `hugo --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68764ca53750832a82897087a96128b1