### PR TITLE
Improve blog post layout and sharing image

### DIFF
--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -14,12 +14,12 @@
       {{ if and (.Site.Params.blog.showDates) (.Lastmod) }}
         <time class="post-updated">{{ i18n "LastUpdated" }}: {{ .Lastmod.Format "2006-01-02" }}</time>
       {{ end }}
-      {{ with .Params.tags }}{{ if $.Site.Params.blog.showTags }}
-        <span class="tags">
-          {{ range $index, $tag := . }}{{ if $index }}, {{ end }}<span class="tag">{{ $tag }}</span>{{ end }}
-        </span>
-      {{ end }}{{ end }}
     </div>
+    {{ with .Params.tags }}{{ if $.Site.Params.blog.showTags }}
+      <div class="post-tags">
+        {{ range $index, $tag := . }}{{ if $index }}, {{ end }}<span class="tag">{{ $tag }}</span>{{ end }}
+      </div>
+    {{ end }}{{ end }}
   </header>
   <div class="post-content">
     {{ .Content }}

--- a/layouts/partials/metadata.html
+++ b/layouts/partials/metadata.html
@@ -7,8 +7,22 @@
 {{ with .Params.images }}
   {{ $image = (index . 0) | absURL }}
 {{ else }}
-  {{ if $imageParam }}
-    {{ $image = printf "img/%s" $imageParam | absURL }}
+  {{ with .Params.cover }}
+    {{ $image = . | absURL }}
+  {{ else }}
+    {{ $mdImg := findRE `!\[[^\]]*\]\(([^)]+)\)` .RawContent }}
+    {{ if gt (len $mdImg) 0 }}
+      {{ $image = replaceRE `!\[[^\]]*\]\(([^)]+)\)` "$1" (index $mdImg 0) | absURL }}
+    {{ else }}
+      {{ $htmlImg := findRE `<img.*?src="([^"]+)"` .Content }}
+      {{ if gt (len $htmlImg) 0 }}
+        {{ $image = replaceRE `<img.*?src="([^"]+)".*` "$1" (index $htmlImg 0) | absURL }}
+      {{ else }}
+        {{ if $imageParam }}
+          {{ $image = printf "img/%s" $imageParam | absURL }}
+        {{ end }}
+      {{ end }}
+    {{ end }}
   {{ end }}
 {{ end }}
 

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -640,10 +640,17 @@ body {
         color: #666;
 }
 
-.blog-post .post-meta .tag {
-        margin-right: 0.25rem;
+.blog-post .post-meta time {
+        display: block;
+        margin-bottom: 0.25rem;
 }
 
-.blog-post .post-meta time {
-        margin-right: 0.5rem;
+.blog-post .post-tags {
+        font-size: 0.9rem;
+        color: #666;
+        margin-top: 0.25rem;
+}
+
+.blog-post .post-tags .tag {
+        margin-right: 0.25rem;
 }


### PR DESCRIPTION
## Summary
- update blog single layout to show title, date and then tags
- style new elements and ensure text is left aligned while page is centered
- enhance metadata partial to pick the first image of a post for social share and fall back to a default

## Testing
- `hugo --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687661b58ab0832a8c408cd9664b96f0