### PR TITLE
Add back links and top button

### DIFF
--- a/content/en/about.md
+++ b/content/en/about.md
@@ -28,3 +28,5 @@ Monitor progress over time to stay on schedule.
 {{< member >}}
 
 {{< social-icons >}}
+
+{{< backlink >}}

--- a/content/en/search.md
+++ b/content/en/search.md
@@ -4,3 +4,5 @@ layout: "search"
 ---
 
 {{< search >}}
+
+{{< backlink >}}

--- a/content/ja/about.md
+++ b/content/ja/about.md
@@ -28,3 +28,5 @@ title: "概要"
 {{< member >}}
 
 {{< social-icons >}}
+
+{{< backlink >}}

--- a/content/ja/search.md
+++ b/content/ja/search.md
@@ -4,3 +4,5 @@ layout: "search"
 ---
 
 {{< search >}}
+
+{{< backlink >}}

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -33,6 +33,8 @@
   translation: "Low"
 - id: Back
   translation: "Back"
+- id: BackToTop
+  translation: "Back to top"
 - id: Start
   translation: "Start"
 - id: End

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -33,6 +33,8 @@
   translation: "低"
 - id: Back
   translation: "戻る"
+- id: BackToTop
+  translation: "トップへ戻る"
 - id: Start
   translation: "開始日"
 - id: End

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -56,6 +56,8 @@
         {{- $lang := .Site.Language.Lang -}}
        <script src="{{ printf "js/today-%s.js" $lang | relURL }}" defer></script>
        <script src="{{ "js/menu-toggle.js" | relURL }}" defer></script>
+       <button id="back-to-top" class="back-to-top" aria-label="{{ i18n "BackToTop" }}">&#x25B2;</button>
+       <script src="{{ "js/back-to-top.js" | relURL }}" defer></script>
 
 	<footer class="site-footer">
 		<div class="container">

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -23,4 +23,7 @@
     {{ end }}
   </div>
 </section>
+<div class="back-link">
+  <a href="{{ .Site.Home.Permalink }}">&larr; {{ i18n "Back" }}</a>
+</div>
 {{ end }}

--- a/layouts/shortcodes/backlink.html
+++ b/layouts/shortcodes/backlink.html
@@ -1,0 +1,3 @@
+<div class="back-link">
+  <a href="{{ "/" | relLangURL }}">&larr; {{ i18n "Back" }}</a>
+</div>

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -715,3 +715,29 @@ body {
 .read-more:hover {
         text-decoration: underline;
 }
+
+/* Back to Top button */
+.back-to-top {
+        position: fixed;
+        right: 1.5rem;
+        bottom: 1.5rem;
+        width: 40px;
+        height: 40px;
+        border: none;
+        border-radius: 50%;
+        background-color: #000;
+        color: #fff;
+        display: none;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        z-index: 1000;
+}
+
+.back-to-top:hover {
+        background-color: #333;
+}
+
+.back-to-top.show {
+        display: flex;
+}

--- a/static/js/back-to-top.js
+++ b/static/js/back-to-top.js
@@ -1,0 +1,16 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const btn = document.getElementById('back-to-top');
+  if (!btn) return;
+
+  window.addEventListener('scroll', () => {
+    if (window.scrollY > 100) {
+      btn.classList.add('show');
+    } else {
+      btn.classList.remove('show');
+    }
+  });
+
+  btn.addEventListener('click', () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  });
+});


### PR DESCRIPTION
## Summary
- add `backlink` shortcode and use on about and search pages
- show Back button on blog list
- add floating Back-to-Top button

## Testing
- `hugo --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876c9daadb0832aaac402d74d7c327b