### PR TITLE
Improve author display

### DIFF
--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -20,9 +20,7 @@
         {{ range $index, $tag := . }}{{ if $index }}, {{ end }}<span class="tag">{{ $tag }}</span>{{ end }}
       </div>
     {{ end }}{{ end }}
-    <div class="author">
-      <span class="author-icon"></span>{{ with .Params.author }}{{ . }}{{ else }}{{ $.Site.Params.author }}{{ end }}
-    </div>
+    {{ partial "author-info.html" . }}
   </header>
   <div class="post-content">
     {{ .Content }}

--- a/layouts/partials/author-info.html
+++ b/layouts/partials/author-info.html
@@ -1,0 +1,24 @@
+{{ $authorName := .Params.author | default $.Site.Params.author }}
+{{ $img := "" }}
+{{ if .Params.author }}
+  {{ $member := site.GetPage (printf "member/%s" .Params.author) }}
+  {{ if $member }}
+    {{ with $member.Params.image }}
+      {{ $path := printf "static/img/%s" . }}
+      {{ if fileExists $path }}
+        {{ $img = printf "img/%s" . | relURL }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+{{ if eq $img "" }}
+  {{ $default := $.Site.Params.profile_image | default "profile.png" }}
+  {{ $dpath := printf "static/img/%s" $default }}
+  {{ if fileExists $dpath }}
+    {{ $img = printf "img/%s" $default | relURL }}
+  {{ end }}
+{{ end }}
+<div class="author">
+  {{ if $img }}<img class="author-icon" src="{{ $img }}" alt="{{ $authorName }}">{{ else }}<span class="author-icon"></span>{{ end }}
+  {{ $authorName }}
+</div>

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -641,13 +641,13 @@ body {
 
 /* Blog post styling */
 .blog-post {
-        margin: 0 auto 2rem;
+        margin: 2rem auto;
         max-width: 800px;
         text-align: left;
         background-color: #ffffff;
         border: 1px solid #e0e0e0;
         border-radius: 8px;
-        padding: 1.5rem;
+        padding: 2rem;
         box-shadow: 0 2px 4px rgba(0,0,0,0.05);
 }
 


### PR DESCRIPTION
## Summary
- adjust blog post margins for better readability
- show author avatar from member data when available and fall back to default profile image

## Testing
- `hugo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876ff24dfcc832a803bbfa464c9017d