### PR TITLE
Replace GA with Tag Manager

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -5,7 +5,7 @@ defaultContentLanguage = "ja"
 defaultContentLanguageInSubdir = true
 enableGitInfo = true
 enableRobotsTXT = true
-googleAnalytics = "G-XXXXXXXXXX"
+googleTagManager = ""
 
 [outputs]
   home = ["HTML", "JSON", "SITEMAP", "ROBOTS"]

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -18,11 +18,12 @@
 	<!-- Static CSS（static/ 配下にある場合） -->
         <link rel="stylesheet" href="{{ "css/styles.css" | relURL }}">
         <link rel="stylesheet" href="{{ "css/search.css" | relURL }}">
-        {{ template "_internal/google_analytics.html" . }}
+        {{ partial "gtm-head.html" . }}
 </head>
 
 <body>
-	<header class="site-header">
+        {{ partial "gtm-body.html" . }}
+        <header class="site-header">
 		<div class="container header-inner">
 			<h1 class="logo"><a href="{{ "" | absLangURL }}">{{ .Site.Title }}</a></h1>
                <nav class="main-nav">

--- a/layouts/partials/gtm-body.html
+++ b/layouts/partials/gtm-body.html
@@ -1,0 +1,5 @@
+{{ with .Site.GoogleTagManager }}
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ . }}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+{{ end }}

--- a/layouts/partials/gtm-head.html
+++ b/layouts/partials/gtm-head.html
@@ -1,0 +1,11 @@
+{{ with .Site.GoogleTagManager }}
+<!-- Google Tag Manager -->
+<script>
+(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','{{ . }}');
+</script>
+<!-- End Google Tag Manager -->
+{{ end }}


### PR DESCRIPTION
## Summary
- remove old Google Analytics config
- add Google Tag Manager config option
- embed GTM snippets in new partials and include them from base template

## Testing
- `hugo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877362f17c0832a95f4c6a8b2664199