### PR TITLE
Exclude blog content from search index

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -53,6 +53,9 @@ enableRobotsTXT = true
     showTags = true
     rss = true
 
+  [params.search]
+    excludeSections = ["blog"]
+
 [languages]
   [languages.ja]
     languageName = "日本語"

--- a/layouts/_default/index.json
+++ b/layouts/_default/index.json
@@ -1,4 +1,9 @@
 {{- $pages := .Site.RegularPages -}}
+{{- with .Site.Params.search.excludeSections }}
+  {{- range . }}
+    {{- $pages = where $pages "Section" "!=" . -}}
+  {{- end }}
+{{- end }}
 [
   {{- range $index, $element := $pages }}
   {


### PR DESCRIPTION
## Summary
- ignore the blog section when building search index
- add search configuration example to config

## Testing
- `hugo --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68819df44148832ab45a4b771902fc4f