### PR TITLE
Use i18n date format for page dates

### DIFF
--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -8,7 +8,7 @@
     {{ range .Pages }}
       <div class="card">
         {{ if $.Site.Params.blog.showDates }}
-          <span class="date">{{ .Date.Format "2006-01-02" }}</span>
+          <span class="date">{{ .Date.Format (i18n "dateFormat") }}</span>
         {{ end }}
         {{ with .Params.tags }}{{ if $.Site.Params.blog.showTags }}
           {{range $index, $tag := . }}{{ if $index }}, {{ end }}<span class="tag">{{ $tag }}</span>{{ end }}

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -9,10 +9,10 @@
     <h1>{{ .Title }}</h1>
     <div class="post-meta">
       {{ if and (.Site.Params.blog.showDates) (.Date) }}
-        <time class="post-date">{{ i18n "Published" }}: {{ .Date.Format "2006-01-02" }}</time>
+        <time class="post-date">{{ i18n "Published" }}: {{ .Date.Format (i18n "dateFormat") }}</time>
       {{ end }}
       {{ if and (.Site.Params.blog.showDates) (.Lastmod) }}
-        <time class="post-updated">{{ i18n "LastUpdated" }}: {{ .Lastmod.Format "2006-01-02" }}</time>
+        <time class="post-updated">{{ i18n "LastUpdated" }}: {{ .Lastmod.Format (i18n "dateFormat") }}</time>
       {{ end }}
     </div>
     {{ with .Params.tags }}{{ if $.Site.Params.blog.showTags }}

--- a/layouts/partials/task-table.html
+++ b/layouts/partials/task-table.html
@@ -17,7 +17,7 @@
         {{ $children := where $pages "Params.parent" .File.BaseFileName }}
         <tr>
             <td><a href="{{ .RelPermalink }}">{{ .Params.title }}</a></td>
-            <td>{{ .Params.start }} - {{ .Params.end }}</td>
+            <td>{{ (time .Params.start).Format (i18n "dateFormat") }} - {{ (time .Params.end).Format (i18n "dateFormat") }}</td>
             <td>
                 <span class="status status-{{ if eq .Params.status "completed" }}completed{{ else if eq .Params.status "in-progress" }}in-progress{{
                     else }}not-started{{ end }}">

--- a/layouts/projects/single.html
+++ b/layouts/projects/single.html
@@ -18,11 +18,11 @@
   <div class="task-details-info">
     <div class="task-details-item">
       <div class="task-details-label">{{ i18n "Start" }}</div>
-      <div class="task-details-value">{{ .Params.start }}</div>
+      <div class="task-details-value">{{ (time .Params.start).Format (i18n "dateFormat") }}</div>
     </div>
     <div class="task-details-item">
       <div class="task-details-label">{{ i18n "End" }}</div>
-      <div class="task-details-value">{{ .Params.end }}</div>
+      <div class="task-details-value">{{ (time .Params.end).Format (i18n "dateFormat") }}</div>
     </div>
     <div class="task-details-item">
       <div class="task-details-label">{{ i18n "Period" }}</div>
@@ -36,9 +36,9 @@
       <div class="task-details-label">{{ i18n "LastUpdated" }}</div>
       <div class="task-details-value">
         {{ with .Params.lastmod }}
-          {{ . | time.Format "2006-01-02" }}
+          {{ . | time.Format (i18n "dateFormat") }}
         {{ else }}
-          {{ .Lastmod.Format "2006-01-02" }}
+          {{ .Lastmod.Format (i18n "dateFormat") }}
         {{ end }}
       </div>
     </div>

--- a/layouts/shortcodes/project-list.html
+++ b/layouts/shortcodes/project-list.html
@@ -23,7 +23,9 @@
         <div class="card">
             <div class="card-body">
                 <h3><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
-                <p class="project-dates">{{ $start }} - {{ $end }}</p>
+                <p class="project-dates">
+                    {{ if $start }}{{ (time $start).Format (i18n "dateFormat") }}{{ end }} - {{ if $end }}{{ (time $end).Format (i18n "dateFormat") }}{{ end }}
+                </p>
                 {{ partial "task-count.html" . }}
                 {{ partial "gantt-progress.html" . }}
             </div>


### PR DESCRIPTION
## Summary
- display all page dates using the `dateFormat` string from `i18n`
- revert changes to JavaScript files

## Testing
- `hugo --gc --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881a7e83400832a860b94c84f2a741b