### PR TITLE
Fix nil start in task table

### DIFF
--- a/layouts/partials/task-table.html
+++ b/layouts/partials/task-table.html
@@ -1,5 +1,5 @@
 {{ with .Pages }}
-{{ $pages := . }}
+{{ $pages := where . "Params.start" "!=" nil }}
 <table class="task-table">
     <thead>
         <tr>


### PR DESCRIPTION
## Summary
- filter tasks that don't specify a start date

## Testing
- `hugo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881b1c76724832aaeb8e5383e45a659