### PR TITLE
Indent lists in content

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -312,6 +312,26 @@ body {
         padding: 2em 0;
 }
 
+/* Indent lists within content for readability */
+.page-content ul,
+.page-content ol,
+.blog-post .post-content ul,
+.blog-post .post-content ol,
+.task-details-value ul,
+.task-details-value ol,
+.task-description ul,
+.task-description ol {
+        margin-left: 1.5em;
+        padding-left: 1em;
+}
+
+.page-content li,
+.blog-post .post-content li,
+.task-details-value li,
+.task-description li {
+        margin-bottom: 0.5em;
+}
+
 /* Task Counts */
 .task-counts {
         display: flex;


### PR DESCRIPTION
## Summary
- indent ordered and unordered lists across blog posts and single pages

## Testing
- `hugo --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881e3f4de28832a8804feb374493a1a