### PR TITLE
Handle translations for language switch

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -38,8 +38,10 @@
                                 </li>
                                 <li>
                                         <select id="lang-switcher" onchange="location.href=this.value">
+                                        {{ $current := . }}
                                         {{ range $.Site.Home.AllTranslations }}
-                                        <option value="{{ .RelPermalink }}" {{ if eq .Lang $.Site.Language.Lang }}selected{{ end }}>{{
+                                        {{ $trans := (where $current.AllTranslations "Lang" .Lang) | first }}
+                                        <option value="{{ if $trans }}{{ $trans.RelPermalink }}{{ else }}{{ .RelPermalink }}{{ end }}" {{ if eq .Lang $.Site.Language.Lang }}selected{{ end }}>{{
                                                 .Language.LanguageName }}</option>
                                         {{ end }}
                                         </select>


### PR DESCRIPTION
## Summary
- keep the current page when switching languages if a translation exists
- fall back to the target language home page otherwise

## Testing
- `hugo` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688219e24910832a95a032a428d3cf58