### PR TITLE
Fix template language switch

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -40,7 +40,9 @@
                                         <select id="lang-switcher" onchange="location.href=this.value">
                                         {{ $current := . }}
                                         {{ range $.Site.Home.AllTranslations }}
-                                        {{ $trans := (where $current.AllTranslations "Lang" .Lang) | first }}
+                                        {{ $trans := "" }}
+                                        {{ $filtered := where $current.AllTranslations "Lang" .Lang }}
+                                        {{ if gt (len $filtered) 0 }}{{ $trans = index $filtered 0 }}{{ end }}
                                         <option value="{{ if $trans }}{{ $trans.RelPermalink }}{{ else }}{{ .RelPermalink }}{{ end }}" {{ if eq .Lang $.Site.Language.Lang }}selected{{ end }}>{{
                                                 .Language.LanguageName }}</option>
                                         {{ end }}


### PR DESCRIPTION
## Summary
- fix the `first` usage when selecting language translations to avoid build errors

## Testing
- `hugo --minify` *(fails: command not found)*
- `apt-get update` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68821c1393c0832a99ddd158280d0d73