### PR TITLE
Fix template error in metadata partial

### DIFF
--- a/layouts/partials/metadata.html
+++ b/layouts/partials/metadata.html
@@ -6,8 +6,8 @@
   {{ $keywords = . }}
 {{ end }}
 
-{{ with .Params.description }}
-  {{ $description = . }}
+{{ if .Params.description }}
+  {{ $description = .Params.description }}
 {{ else if eq .Section "projects" }}
   {{ with .Parent.Params.description }}
     {{ $description = . }}


### PR DESCRIPTION
## Summary
- fix invalid `else if` in metadata partial

## Testing
- `hugo --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882c374793c832a9c902084dbf0d3b6