### PR TITLE
Add dedicated member pages

### DIFF
--- a/layouts/member/single.html
+++ b/layouts/member/single.html
@@ -1,0 +1,18 @@
+{{ define "main" }}
+<article class="member-detail">
+  <h1 class="member-title">{{ .Title }}</h1>
+  {{ with .Params.image }}
+    {{ $img := printf "static/img/%s" . }}
+    {{ if fileExists $img }}
+      <div class="member-photo-wrapper">
+        <img src="{{ printf "img/%s" . | relURL }}" alt="{{ $.Title }}" class="member-photo">
+      </div>
+    {{ end }}
+  {{ end }}
+  <div class="member-bio">
+    {{ .Content }}
+  </div>
+</article>
+
+{{ partial "backlink-single.html" . }}
+{{ end }}

--- a/layouts/partials/member.html
+++ b/layouts/partials/member.html
@@ -4,16 +4,18 @@
     {{ range (site.GetPage "section" "member").Pages }}
       {{ $member := . }}
       <div class="member-item">
-        {{ with $member.Params.image }}
-          {{ $img := printf "static/img/%s" . }}
-          {{ if fileExists $img }}
-            <div class="member-photo-wrapper">
-              <img src="{{ printf "img/%s" . | relURL }}" alt="{{ $member.Title }}" class="member-photo">
-            </div>
+        <a href="{{ $member.RelPermalink }}" class="member-link">
+          {{ with $member.Params.image }}
+            {{ $img := printf "static/img/%s" . }}
+            {{ if fileExists $img }}
+              <div class="member-photo-wrapper">
+                <img src="{{ printf "img/%s" . | relURL }}" alt="{{ $member.Title }}" class="member-photo">
+              </div>
+            {{ end }}
           {{ end }}
-        {{ end }}
-        <h3>{{ .Title }}</h3>
-        <div class="member-bio">{{ .Content }}</div>
+          <h3>{{ $member.Title }}</h3>
+          <div class="member-bio">{{ $member.Content }}</div>
+        </a>
       </div>
     {{ end }}
   </div>

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -524,6 +524,15 @@ body {
         border-radius: 50%;
 }
 
+/* Make entire member item clickable */
+.member-link {
+        text-decoration: none;
+        color: inherit;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+}
+
 /* Social share buttons */
 .share-box {
         margin-top: 1rem;


### PR DESCRIPTION
## Summary
- link each member in the member list to its own page
- style linked member items
- add a single layout for member pages that shows the image

## Testing
- `hugo version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688401849a1c832a88601fbfe30aef85