### PR TITLE
feat: add search icon and close label

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -55,3 +55,7 @@
   translation: "Blog"
 - id: ReadMore
   translation: "Read more"
+- id: openMenu
+  translation: "Open menu"
+- id: closeMenu
+  translation: "Close"

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -55,3 +55,7 @@
   translation: "ブログ"
 - id: ReadMore
   translation: "続きを読む"
+- id: openMenu
+  translation: "メニューを開く"
+- id: closeMenu
+  translation: "閉じる"

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -33,9 +33,9 @@
                <nav class="main-nav">
                        <button id="menu-toggle" class="menu-toggle" aria-label="{{ i18n "openMenu" }}">&#x22EE;</button>
                        <ul>
-                                <li class="menu-close-item">
-                                        <button id="menu-close" class="menu-close" aria-label="{{ i18n "openMenu" }}">&times;</button>
-                                </li>
+                               <li class="menu-close-item">
+                                       <button id="menu-close" class="menu-close" aria-label="{{ i18n "closeMenu" }}">&#x2717; {{ i18n "closeMenu" }}</button>
+                               </li>
                                 <li>
                                         <select id="lang-switcher" onchange="location.href=this.value">
                                         {{ $current := . }}
@@ -48,9 +48,13 @@
                                         {{ end }}
                                         </select>
                                 </li>
-                                {{ range .Site.Menus.main }}
-                                <li><a href="{{ .URL | relURL }}">{{ .Name }}</a></li>
-                                {{ end }}
+                               {{ range .Site.Menus.main }}
+                               {{ if eq .Identifier "search" }}
+                               <li class="menu-item-search"><a href="{{ .URL | relURL }}" aria-label="{{ .Name }}"><img src="{{ "img/search-icon.png" | relURL }}" alt="" class="search-icon"><span class="search-text">{{ .Name }}</span></a></li>
+                               {{ else }}
+                               <li><a href="{{ .URL | relURL }}">{{ .Name }}</a></li>
+                               {{ end }}
+                               {{ end }}
                                 <li id="today-date">
                                 </li>
                         </ul>

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -81,6 +81,17 @@ body {
         text-align: right;
 }
 
+.menu-item-search .search-icon {
+        display: inline-block;
+        width: 1em;
+        height: 1em;
+        vertical-align: middle;
+}
+
+.menu-item-search .search-text {
+        display: none;
+}
+
 .main-nav a:hover {
         background-color: #efefef;
         border-radius: 4px;
@@ -116,6 +127,14 @@ body {
                 width: auto;
                 text-align: center;
                 z-index: 1001;
+        }
+
+        .menu-item-search .search-icon {
+                display: none;
+        }
+
+        .menu-item-search .search-text {
+                display: inline;
         }
 
         .main-nav ul.open {


### PR DESCRIPTION
## Summary
- swap desktop search menu label for `img/search-icon.png`
- show "✗ Close" text in mobile menu
- add i18n entries for opening and closing the menu

## Testing
- `hugo --minify` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68952cb91ea0832aa03abd4b39f1f273