### PR TITLE
Use image for mobile menu icon

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -31,7 +31,9 @@
 		<div class="container header-inner">
 			<h1 class="logo"><a href="{{ "" | absLangURL }}">{{ .Site.Title }}</a></h1>
                <nav class="main-nav">
-                       <button id="menu-toggle" class="menu-toggle" aria-label="{{ i18n "openMenu" }}">&#x22EE;</button>
+                       <button id="menu-toggle" class="menu-toggle" aria-label="{{ i18n "openMenu" }}">
+                               <img src="{{ "img/menu-icon.png" | relURL }}" alt="{{ i18n "openMenu" }}" width="60" height="60">
+                       </button>
                        <ul>
                                <li class="menu-close-item">
                                        <button id="menu-close" class="menu-close" aria-label="{{ i18n "closeMenu" }}">&#x2717; {{ i18n "closeMenu" }}</button>

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -65,9 +65,14 @@ body {
         display: none;
         background: none;
         border: none;
-        font-size: 1.5rem;
-        padding: 0.5em;
+        padding: 0;
         cursor: pointer;
+}
+
+.menu-toggle img {
+        width: 60px;
+        height: 60px;
+        display: block;
 }
 
 .menu-close {


### PR DESCRIPTION
## Summary
- Replace the mobile menu toggle character with an image placeholder
- Adjust menu toggle CSS for 60x60 image

## Testing
- `hugo` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68953c2da120832a8aea53079380e9d8