### PR TITLE
Make images responsive across layouts

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -58,6 +58,11 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+img {
+  max-width: 100%;
+  height: auto;
+}
+
 .container {
   width: 90%;
   max-width: 1200px;
@@ -1243,8 +1248,9 @@ select:focus {
 }
 
 .profile-photo {
-  width: 200px;
-  height: 200px;
+  width: min(60vw, 200px);
+  aspect-ratio: 1 / 1;
+  height: auto;
   object-fit: cover;
   border-radius: 50%;
   box-shadow: var(--shadow-medium);
@@ -1252,6 +1258,23 @@ select:focus {
 
 .profile-author {
   text-align: center;
+}
+
+.author {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+}
+
+.author .author-icon {
+  width: min(12vw, 56px);
+  aspect-ratio: 1 / 1;
+  height: auto;
+  border-radius: 50%;
+  object-fit: cover;
+  box-shadow: var(--shadow-light);
 }
 
 /* Member List */
@@ -1287,8 +1310,9 @@ select:focus {
 }
 
 .member-photo {
-  width: 120px;
-  height: 120px;
+  width: min(40vw, 120px);
+  aspect-ratio: 1 / 1;
+  height: auto;
   object-fit: cover;
   border-radius: 50%;
   box-shadow: var(--shadow-light);


### PR DESCRIPTION
## Summary
- add a global rule so inline content images automatically scale with their containers
- adjust profile, member, and author avatar styles to maintain circular crops while shrinking on small screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d325b57b08832ab2831025a1d6e18f