### PR TITLE
Fix Gantt arrow fill color

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1102,7 +1102,7 @@ select:focus {
 
 .gantt .arrow {
   stroke: var(--neutral-color) !important;
-  fill: var(--neutral-color) !important;
+  fill: none !important;
   stroke-width: 1.5px !important;
 }
 


### PR DESCRIPTION
## Summary
- prevent Frappe Gantt dependency arrows from being filled with a solid color by disabling the fill

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3dbec1730832a9928c3d49af38bb5