### PR TITLE
Improve mobile menu panel contrast

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -810,10 +810,13 @@ img {
     right: -250px;
     width: 200px;
     height: 100%;
-    background: var(--card-background);
+    background-color: var(--card-background);
+    background-color: rgba(246, 248, 250, 0.95);
+    backdrop-filter: blur(16px);
     flex-direction: column;
     padding: 2em 1em;
-    box-shadow: -2px 0 5px rgba(0,0,0,0.1);
+    border-left: 1px solid var(--border-color);
+    box-shadow: -12px 0 24px rgba(27, 31, 36, 0.12);
     transition: right var(--transition-normal);
     z-index: 1000;
   }


### PR DESCRIPTION
## Summary
- adjust the responsive navigation panel background to use a subtle tinted surface
- add a border and stronger shadow so the menu edge is easy to distinguish

## Testing
- hugo version *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d3e66c9828832abd76e5c5beb34622