### PR TITLE
Add GitHub Pages deployment workflow and update site baseURL to GitHub Pages

### DIFF
--- a/.github/workflows/hugo-pages.yml
+++ b/.github/workflows/hugo-pages.yml
@@ -1,0 +1,57 @@
+name: Deploy Hugo site to Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: '0.150.1'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: ${{ env.HUGO_VERSION }}
+          extended: true
+
+      - name: Build
+        run: hugo --minify --baseURL "${{ steps.pages.outputs.base_url }}/"
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./public
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://cmdwolftech.gitlab.io/tasklist/"
+baseURL = "https://cmdwolftech.github.io/tasklist/"
 title = "ProjectBoard"
 buildFuture = true
 defaultContentLanguage = "ja"

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://cmdwolftech.gitlab.io/tasklist/"
+baseURL = "https://cmdwolftech.github.io/tasklist/"
 title = "ProjectBoard"
 buildFuture = true
 defaultContentLanguage = "ja"


### PR DESCRIPTION
### Motivation
- Configure automated deployment of the Hugo site to GitHub Pages.
- Point the site's `baseURL` from the previous GitLab Pages hostname to the GitHub Pages hostname for this repository.

### Description
- Add `.github/workflows/hugo-pages.yml` to build and deploy the site using `actions/checkout@v4`, `actions/configure-pages@v5`, `peaceiris/actions-hugo@v3`, `actions/upload-pages-artifact@v3`, and `actions/deploy-pages@v4`.
- Configure the workflow with a `build` job that sets `HUGO_VERSION` to `0.150.1` and runs `hugo --minify --baseURL "${{ steps.pages.outputs.base_url }}/"` and a `deploy` job that uses the uploaded artifact to deploy to GitHub Pages.
- Update `baseURL` in `config.toml` and `exampleSite/config.toml` from `https://cmdwolftech.gitlab.io/tasklist/` to `https://cmdwolftech.github.io/tasklist/` to match GitHub Pages.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f190b4b500832aaace044cb00fce49)