### PR TITLE
Add Hugo GitHub Pages workflow and update site baseURL/language settings

### DIFF
--- a/.github/workflows/hugo-pages.yml
+++ b/.github/workflows/hugo-pages.yml
@@ -1,0 +1,57 @@
+name: Deploy Hugo site to Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: '0.150.1'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: ${{ env.HUGO_VERSION }}
+          extended: true
+
+      - name: Build
+        run: hugo --minify --baseURL "${{ steps.pages.outputs.base_url }}/"
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./public
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/config.toml
+++ b/config.toml
@@ -1,8 +1,8 @@
-baseURL = "https://cmdwolftech.gitlab.io/tasklist/"
+baseURL = "https://cmdwolftech.github.io/tasklist/"
 title = "ProjectBoard"
 buildFuture = true
 defaultContentLanguage = "ja"
-defaultContentLanguageInSubdir = true
+defaultContentLanguageInSubdir = false
 enableGitInfo = true
 enableRobotsTXT = true
 summaryLength = 70

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,8 +1,8 @@
-baseURL = "https://cmdwolftech.gitlab.io/tasklist/"
+baseURL = "https://cmdwolftech.github.io/tasklist/"
 title = "ProjectBoard"
 buildFuture = true
 defaultContentLanguage = "ja"
-defaultContentLanguageInSubdir = true
+defaultContentLanguageInSubdir = false
 enableGitInfo = true
 enableRobotsTXT = true
 theme = "tasklist"


### PR DESCRIPTION
### Motivation
- Migrate site deployment from GitLab Pages to GitHub Pages and add an automated build/deploy workflow. 
- Ensure the Hugo build uses the correct `baseURL` for GitHub Pages. 
- Disable language subdirectory output to match the intended site structure.

### Description
- Add GitHub Actions workflow at `.github/workflows/hugo-pages.yml` that checks out the repo, configures Pages, installs Hugo (`peaceiris/actions-hugo@v3`), runs `hugo --minify --baseURL "${{ steps.pages.outputs.base_url }}/"`, uploads the `./public` artifact, and deploys with `actions/deploy-pages@v4`.
- Update `config.toml` to set `baseURL` to `https://cmdwolftech.github.io/tasklist/` and change `defaultContentLanguageInSubdir` to `false`.
- Mirror the same `baseURL` and `defaultContentLanguageInSubdir` change in `exampleSite/config.toml`.

### Testing
- No automated tests were executed as part of this change. 
- The new workflow is configured to run on `push` to `main` and via `workflow_dispatch`, and will perform a Hugo build and deploy when triggered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f190b4b500832aaace044cb00fce49)